### PR TITLE
Fix invalid ref declaration with useState

### DIFF
--- a/components/SearchBar.vue
+++ b/components/SearchBar.vue
@@ -56,12 +56,12 @@ const props = defineProps({
   }
 });
 
-const searchInput = useState(null);
+const searchInput = useState("seachInput", () => null);
 const setSearchInput = (newSearchInput) => {
   searchInput.value = newSearchInput;
 }
 
-const loading = useState(false);
+const loading = useState("loading", () => false);
 const setLoading = (newLoading) => {
   loading.value = newLoading;
 }

--- a/components/TransactionForm.vue
+++ b/components/TransactionForm.vue
@@ -94,17 +94,17 @@ const props = defineProps({
   },
 });
 
-const recipient = useState(null);
+const recipient = useState("recipient", () => null);
 const setRecipient = (newRecipient) => {
   recipient.value = newRecipient;
 }
 
-const amount = useState(null);
+const amount = useState("amount", () => null);
 const setAmount = (newAmount) => {
   amount.value = newAmount;
 }
 
-const loading = useState(false);
+const loading = useState("loading", () => false);
 const setLoading = (newLoading) => {
   loading.value = newLoading;
 }


### PR DESCRIPTION
Includes a fix for my mistaken relapses to Vue syntax for ref(someValue) instead of keeping to the Nuxt syntax for useState("varName", () => someValue).

For example, I was writing:

```javascript
const searchInput = useState("seachInput", () => null);
```

instead of the correct way for Nuxt 3:

```javascript
const searchInput = useState(null);
```

This PR fixes any improper usage of useState to comply with Nuxt syntax.